### PR TITLE
use long long for time in ffi

### DIFF
--- a/rust-src/time.rs
+++ b/rust-src/time.rs
@@ -1,4 +1,4 @@
-use std::ffi::c_ulong;
+use std::ffi::c_ulonglong;
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 use std::sync::OnceLock;
@@ -11,28 +11,28 @@ use crate::{free_haskell_fun_ptr, IcedMessage, Message};
 
 static STARTED_AT: OnceLock<Instant> = OnceLock::new();
 
-type OnEvery = extern "C" fn(micros: c_ulong) -> Message;
+type OnEvery = extern "C" fn(micros: c_ulonglong) -> Message;
 
 #[no_mangle]
-extern "C" fn duration_from_secs(value: c_ulong) -> *mut Duration {
+extern "C" fn duration_from_secs(value: c_ulonglong) -> *mut Duration {
     let duration = Duration::from_secs(value);
     Box::into_raw(Box::new(duration))
 }
 
 #[no_mangle]
-extern "C" fn duration_from_millis(value: c_ulong) -> *mut Duration {
+extern "C" fn duration_from_millis(value: c_ulonglong) -> *mut Duration {
     let duration = Duration::from_millis(value);
     Box::into_raw(Box::new(duration))
 }
 
 #[no_mangle]
-extern "C" fn duration_from_micros(value: c_ulong) -> *mut Duration {
+extern "C" fn duration_from_micros(value: c_ulonglong) -> *mut Duration {
     let duration = Duration::from_micros(value);
     Box::into_raw(Box::new(duration))
 }
 
 #[no_mangle]
-extern "C" fn duration_from_nanos(value: c_ulong) -> *mut Duration {
+extern "C" fn duration_from_nanos(value: c_ulonglong) -> *mut Duration {
     let duration = Duration::from_nanos(value);
     Box::into_raw(Box::new(duration))
 }
@@ -98,6 +98,6 @@ extern "C" fn iced_time_every(
 }
 
 #[no_mangle]
-extern "C" fn time_micros_since_start() -> c_ulong {
+extern "C" fn time_micros_since_start() -> c_ulonglong {
     time_passed_micros(Instant::now())
 }

--- a/src/Iced/Time.hs
+++ b/src/Iced/Time.hs
@@ -40,7 +40,7 @@ delayNanos = delay . fromNanos
 foreign import ccall "iced_time_every"
   time_every :: Duration -> FunPtr (NativeOnEvery message) -> IO (Subscription message)
 
-type NativeOnEvery message = CULong -> IO (StablePtr message)
+type NativeOnEvery message = CULLong -> IO (StablePtr message)
 
 foreign import ccall "wrapper"
   makeOnEveryCallback :: NativeOnEvery message -> IO (FunPtr (NativeOnEvery message))
@@ -71,7 +71,7 @@ everyNanos :: Word64 -> OnEvery message -> IO (Subscription message)
 everyNanos n = every (fromNanos n)
 
 foreign import ccall "time_micros_since_start"
-  micros_since_start :: IO CULong
+  micros_since_start :: IO CULLong
 
 -- Number of microseconds since STARTED_AT static variable in Rust
 -- STARTED_AT is initialised when first accessed

--- a/src/Iced/Time/Duration.hs
+++ b/src/Iced/Time/Duration.hs
@@ -15,25 +15,25 @@ data NativeDuration
 type Duration = Ptr NativeDuration
 
 foreign import ccall "duration_from_secs"
-  from_secs :: CULong -> IO Duration
+  from_secs :: CULLong -> IO Duration
 
 fromSecs :: Word64 -> IO Duration
-fromSecs = from_secs . CULong
+fromSecs = from_secs . CULLong
 
 foreign import ccall "duration_from_millis"
-  from_millis :: CULong -> IO Duration
+  from_millis :: CULLong -> IO Duration
 
 fromMillis :: Word64 -> IO Duration
-fromMillis = from_millis . CULong
+fromMillis = from_millis . CULLong
 
 foreign import ccall "duration_from_micros"
-  from_micros :: CULong -> IO Duration
+  from_micros :: CULLong -> IO Duration
 
 fromMicros :: Word64 -> IO Duration
-fromMicros = from_micros . CULong
+fromMicros = from_micros . CULLong
 
 foreign import ccall "duration_from_nanos"
-  from_nanos :: CULong -> IO Duration
+  from_nanos :: CULLong -> IO Duration
 
 fromNanos :: Word64 -> IO Duration
-fromNanos = from_nanos . CULong
+fromNanos = from_nanos . CULLong


### PR DESCRIPTION
`c_ulong` is `u32` on Windowd and `u64` on Linux
`c_ulonglong` "will almost always be `u64`"
https://doc.rust-lang.org/std/ffi/type.c_ulonglong.html

Related to #19 