### PR TITLE
Sorted attribute reexports

### DIFF
--- a/examples/buttonStyles/Main.hs
+++ b/examples/buttonStyles/Main.hs
@@ -4,6 +4,7 @@ import Iced
 import Iced.Attribute
 import Iced.Attribute.Alignment
 import Iced.Color
+import Iced.Style
 import Iced.Theme
 import Iced.Widget
 import Iced.Widget.Button qualified as Button

--- a/examples/canvas/build.sh
+++ b/examples/canvas/build.sh
@@ -7,7 +7,7 @@ fi
 ghc -Wall -i../../src \
   -odir ../../build \
   -hidir ../../build \
-  ../../target/debug/libiced_hs.a \
+  ../../libiced_hs.a \
   ${USE_LINKER+-optl -fuse-ld="$USE_LINKER"} \
   -o main \
   Main.hs

--- a/examples/markdown/Main.hs
+++ b/examples/markdown/Main.hs
@@ -3,7 +3,7 @@
 
 module Main where
 
-import Data.List
+import Data.List (intercalate)
 
 import Iced
 import Iced.Attribute

--- a/examples/textEditor/Main.hs
+++ b/examples/textEditor/Main.hs
@@ -6,6 +6,7 @@ module Main where
 import Iced
 import Iced.Attribute
 import Iced.Color
+import Iced.Style
 import Iced.Theme
 import Iced.Widget
 import Iced.Widget.TextEditor qualified as TextEditor

--- a/iced-hs.cabal
+++ b/iced-hs.cabal
@@ -152,7 +152,6 @@ library
     Iced.Attribute.Size
     Iced.Attribute.SliderCommon
     Iced.Attribute.Spacing
-    Iced.Attribute.Status
     Iced.Attribute.Style
     Iced.Attribute.Text
     Iced.Color
@@ -171,8 +170,8 @@ library
     Iced.Settings
     Iced.Size
     Iced.Style
-    Iced.Style.Container
     Iced.Style.Internal
+    Iced.Style.Status
     Iced.Subscription
     Iced.Theme
     Iced.Time

--- a/src/Iced/Attribute.hs
+++ b/src/Iced/Attribute.hs
@@ -1,9 +1,11 @@
 module Iced.Attribute (
+  -- shared attributes
   module Iced.Attribute.Alignment,
   module Iced.Attribute.Color,
   module Iced.Attribute.Icon,
   module Iced.Attribute.Length,
   module Iced.Attribute.LineHeight,
+  module Iced.Attribute.OnInput,
   module Iced.Attribute.OnPress,
   module Iced.Attribute.OnRelease,
   module Iced.Attribute.Padding,
@@ -11,21 +13,70 @@ module Iced.Attribute (
   module Iced.Attribute.Size,
   module Iced.Attribute.SliderCommon,
   module Iced.Attribute.Spacing,
-  module Iced.Attribute.Status,
   module Iced.Attribute.Style,
+  -- widget attributes
+  module Iced.Widget.Button,
+  module Iced.Widget.Checkbox,
+  module Iced.Widget.ComboBox,
+  module Iced.Widget.Container,
+  module Iced.Widget.MouseArea,
+  module Iced.Widget.TextEditor,
+  module Iced.Widget.TextInput,
+  module Iced.Widget.Tooltip,
 ) where
 
+--
+-- Reexport shared attributes
+--
+
 import Iced.Attribute.Alignment (alignX, alignY)
-import Iced.Attribute.Color
-import Iced.Attribute.Icon
-import Iced.Attribute.Length
-import Iced.Attribute.LineHeight
+import Iced.Attribute.Color (color)
+import Iced.Attribute.Icon (icon)
+import Iced.Attribute.Length (Length (..), height, width)
+import Iced.Attribute.LineHeight (LineHeight (..), lineHeight)
+import Iced.Attribute.OnInput (onInput)
 import Iced.Attribute.OnPress (onPress)
 import Iced.Attribute.OnRelease (onRelease)
 import Iced.Attribute.Padding (padding, padding2, padding4)
-import Iced.Attribute.Placeholder
-import Iced.Attribute.Size
-import Iced.Attribute.SliderCommon
-import Iced.Attribute.Spacing
-import Iced.Attribute.Status
-import Iced.Attribute.Style
+import Iced.Attribute.Placeholder (placeholder)
+import Iced.Attribute.Size (size)
+import Iced.Attribute.SliderCommon (addDefault, shiftStep, step)
+import Iced.Attribute.Spacing (spacing)
+import Iced.Attribute.Style (style)
+--
+-- Reexport widget attributes
+--
+
+import Iced.Widget.Button (onPressIf)
+import Iced.Widget.Checkbox (
+  onToggle,
+  onToggleIf,
+  textLineHeight,
+  textShaping,
+  textSize,
+ )
+import Iced.Widget.ComboBox (
+  onClose,
+  onOptionHovered,
+ )
+import Iced.Widget.Container (
+  centerX,
+  centerY,
+ )
+import Iced.Widget.MouseArea (
+  onDoubleClick,
+  onEnter,
+  onExit,
+  onMiddlePress,
+  onMiddleRelease,
+  onMove,
+  onRightPress,
+  onRightRelease,
+ )
+import Iced.Widget.TextEditor (onAction)
+import Iced.Widget.TextInput (onSubmit)
+import Iced.Widget.Tooltip (
+  gap,
+  snapWithViewport,
+  tooltip,
+ )

--- a/src/Iced/Attribute/Style.hs
+++ b/src/Iced/Attribute/Style.hs
@@ -1,40 +1,4 @@
 module Iced.Attribute.Style where
 
-import Iced.Color
-
 class UseStyle value attribute where
   style :: value -> attribute
-
-class UseBackground attribute where
-  background :: Color -> attribute
-
-class UseBar attribute where
-  bar :: Color -> attribute
-
-class UseBorder attribute where
-  -- color width radius
-  border :: Color -> Float -> Float -> attribute
-
-class UseBorderColor attribute where
-  borderColor :: Color -> attribute
-
-class UseBorderWidth attribute where
-  borderWidth :: Float -> attribute
-
-class UseDotColor attribute where
-  dotColor :: Color -> attribute
-
-class UseIconColor attribute where
-  iconColor :: Color -> attribute
-
-class UseHandleColor attribute where
-  handleColor :: Color -> attribute
-
-class UsePlaceholderColor attribute where
-  placeholderColor :: Color -> attribute
-
-class UseTextColor attribute where
-  textColor :: Color -> attribute
-
-class UseSelectionColor attribute where
-  selectionColor :: Color -> attribute

--- a/src/Iced/Style.hs
+++ b/src/Iced/Style.hs
@@ -1,5 +1,30 @@
 module Iced.Style (
-  module Iced.Style.Container,
+  module Iced.Style.Internal,
+  module Iced.Style.Status,
 ) where
 
-import Iced.Style.Container
+--
+-- Reexport style attributes
+--
+
+import Iced.Style.Internal (
+  background,
+  bar,
+  border,
+  borderColor,
+  borderWidth,
+  dotColor,
+  handleColor,
+  iconColor,
+  placeholderColor,
+  selectionColor,
+  textColor,
+ )
+import Iced.Style.Status (
+  active,
+  disabled,
+  focused,
+  hovered,
+  opened,
+  pressed,
+ )

--- a/src/Iced/Style/Container.hs
+++ b/src/Iced/Style/Container.hs
@@ -1,1 +1,0 @@
-module Iced.Style.Container where

--- a/src/Iced/Style/Internal.hs
+++ b/src/Iced/Style/Internal.hs
@@ -1,1 +1,37 @@
 module Iced.Style.Internal where
+
+import Iced.Color
+
+class UseBackground attribute where
+  background :: Color -> attribute
+
+class UseBar attribute where
+  bar :: Color -> attribute
+
+class UseBorder attribute where
+  -- color width radius
+  border :: Color -> Float -> Float -> attribute
+
+class UseBorderColor attribute where
+  borderColor :: Color -> attribute
+
+class UseBorderWidth attribute where
+  borderWidth :: Float -> attribute
+
+class UseDotColor attribute where
+  dotColor :: Color -> attribute
+
+class UseIconColor attribute where
+  iconColor :: Color -> attribute
+
+class UseHandleColor attribute where
+  handleColor :: Color -> attribute
+
+class UsePlaceholderColor attribute where
+  placeholderColor :: Color -> attribute
+
+class UseTextColor attribute where
+  textColor :: Color -> attribute
+
+class UseSelectionColor attribute where
+  selectionColor :: Color -> attribute

--- a/src/Iced/Style/Status.hs
+++ b/src/Iced/Style/Status.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE FunctionalDependencies #-}
 
-module Iced.Attribute.Status where
+module Iced.Style.Status where
 
 class UseActive value attribute | attribute -> value where
   active :: value -> attribute

--- a/src/Iced/Widget.hs
+++ b/src/Iced/Widget.hs
@@ -1,85 +1,59 @@
 module Iced.Widget (
-  module Iced.Widget.Button,
-  module Iced.Widget.Canvas,
-  module Iced.Widget.Checkbox,
-  module Iced.Widget.Column,
-  module Iced.Widget.ComboBox,
-  module Iced.Widget.Container,
-  module Iced.Widget.Image,
-  module Iced.Widget.Markdown,
-  module Iced.Widget.MouseArea,
-  module Iced.Widget.PickList,
-  module Iced.Widget.ProgressBar,
-  module Iced.Widget.Radio,
-  module Iced.Widget.Responsive,
-  module Iced.Widget.Row,
-  module Iced.Widget.Scrollable,
-  module Iced.Widget.Slider,
+  button,
+  canvas,
+  checkbox,
+  column,
+  comboBox,
+  container,
+  image,
+  markdown,
+  mouseArea,
+  pickList,
+  progressBar,
+  radio,
+  responsive,
+  row,
+  scrollable,
+  slider,
   module Iced.Widget.Space,
-  module Iced.Widget.Text,
-  module Iced.Widget.TextEditor,
-  module Iced.Widget.TextInput,
-  module Iced.Widget.Toggler,
-  module Iced.Widget.Tooltip,
-  module Iced.Widget.VerticalSlider,
+  text,
+  textEditor,
+  textInput,
+  toggler,
+  tooltip,
+  verticalSlider,
 ) where
 
 --
--- Reexport only key widget constructors and attributes
+-- Reexport only key widget constructors
 --
 
-import Iced.Widget.Button (
-  button,
-  onPressIf,
- )
+import Iced.Widget.Button (button)
 import Iced.Widget.Canvas (canvas)
-import Iced.Widget.Checkbox (
-  checkbox,
-  onToggle,
-  onToggleIf,
-  textLineHeight,
-  textShaping,
-  textSize,
- )
-import Iced.Widget.Column
-import Iced.Widget.ComboBox hiding (State, newState)
-import Iced.Widget.Container (
-  centerX,
-  centerY,
-  container,
- )
+import Iced.Widget.Checkbox (checkbox)
+import Iced.Widget.Column (column)
+import Iced.Widget.ComboBox (comboBox)
+import Iced.Widget.Container (container)
 import Iced.Widget.Image (image)
 import Iced.Widget.Markdown (markdown)
-import Iced.Widget.MouseArea (
-  mouseArea,
-  onDoubleClick,
-  onEnter,
-  onExit,
-  onMiddlePress,
-  onMiddleRelease,
-  onMove,
-  onRelease,
-  onRightPress,
-  onRightRelease,
- )
+import Iced.Widget.MouseArea (mouseArea)
 import Iced.Widget.PickList (pickList)
 import Iced.Widget.ProgressBar (progressBar)
 import Iced.Widget.Radio (radio)
-import Iced.Widget.Responsive
-import Iced.Widget.Row
-import Iced.Widget.Scrollable
-import Iced.Widget.Slider
-import Iced.Widget.Space
+import Iced.Widget.Responsive (responsive)
+import Iced.Widget.Row (row)
+import Iced.Widget.Scrollable (scrollable)
+import Iced.Widget.Slider (slider)
+import Iced.Widget.Space (
+  horizontalSpace,
+  space,
+  spaceHeight,
+  spaceWidth,
+  verticalSpace,
+ )
 import Iced.Widget.Text (text)
-import Iced.Widget.TextEditor (
-  onAction,
-  textEditor,
- )
-import Iced.Widget.TextInput (
-  onInput,
-  onSubmit,
-  textInput,
- )
-import Iced.Widget.Toggler
-import Iced.Widget.Tooltip hiding (Position (..))
-import Iced.Widget.VerticalSlider
+import Iced.Widget.TextEditor (textEditor)
+import Iced.Widget.TextInput (textInput)
+import Iced.Widget.Toggler (toggler)
+import Iced.Widget.Tooltip (tooltip)
+import Iced.Widget.VerticalSlider (verticalSlider)

--- a/src/Iced/Widget/Button.hs
+++ b/src/Iced/Widget/Button.hs
@@ -20,10 +20,11 @@ import Iced.Attribute.Internal
 import Iced.Attribute.LengthFFI
 import Iced.Attribute.OnPress
 import Iced.Attribute.PaddingFFI
-import Iced.Attribute.Status
 import Iced.Attribute.Style
 import Iced.ColorFFI
 import Iced.Element
+import Iced.Style.Internal
+import Iced.Style.Status
 import Iced.Theme
 
 data NativeButton

--- a/src/Iced/Widget/Checkbox.hs
+++ b/src/Iced/Widget/Checkbox.hs
@@ -26,11 +26,12 @@ import Iced.Attribute.LengthFFI
 import Iced.Attribute.LineHeightFFI
 import Iced.Attribute.Size
 import Iced.Attribute.Spacing
-import Iced.Attribute.Status
 import Iced.Attribute.Style
 import Iced.Attribute.Text
 import Iced.ColorFFI
 import Iced.Element
+import Iced.Style.Internal
+import Iced.Style.Status
 import Iced.Theme
 
 data NativeCheckbox

--- a/src/Iced/Widget/Container.hs
+++ b/src/Iced/Widget/Container.hs
@@ -19,6 +19,7 @@ import Iced.Attribute.PaddingFFI
 import Iced.Attribute.Style
 import Iced.ColorFFI
 import Iced.Element
+import Iced.Style.Internal
 import Iced.Theme
 
 data NativeContainer

--- a/src/Iced/Widget/PickList.hs
+++ b/src/Iced/Widget/PickList.hs
@@ -19,10 +19,11 @@ import Iced.Attribute.Internal
 import Iced.Attribute.LengthFFI
 import Iced.Attribute.PaddingFFI
 import Iced.Attribute.Placeholder
-import Iced.Attribute.Status
 import Iced.Attribute.Style
 import Iced.ColorFFI
 import Iced.Element
+import Iced.Style.Internal
+import Iced.Style.Status
 import Iced.Theme
 
 data NativePickList

--- a/src/Iced/Widget/ProgressBar.hs
+++ b/src/Iced/Widget/ProgressBar.hs
@@ -16,6 +16,7 @@ import Iced.Attribute.LengthFFI
 import Iced.Attribute.Style
 import Iced.ColorFFI
 import Iced.Element
+import Iced.Style.Internal
 import Iced.Theme
 
 data NativeProgressBar

--- a/src/Iced/Widget/Radio.hs
+++ b/src/Iced/Widget/Radio.hs
@@ -16,10 +16,11 @@ import Foreign.C.Types
 
 import Iced.Attribute.Internal
 import Iced.Attribute.LengthFFI
-import Iced.Attribute.Status
 import Iced.Attribute.Style
 import Iced.ColorFFI
 import Iced.Element
+import Iced.Style.Internal
+import Iced.Style.Status
 import Iced.Theme
 
 data NativeRadio

--- a/src/Iced/Widget/TextEditor.hs
+++ b/src/Iced/Widget/TextEditor.hs
@@ -24,10 +24,11 @@ import Foreign.C.Types
 import Iced.Attribute.Internal
 import Iced.Attribute.LengthFFI
 import Iced.Attribute.PaddingFFI
-import Iced.Attribute.Status
 import Iced.Attribute.Style
 import Iced.ColorFFI
 import Iced.Element
+import Iced.Style.Internal
+import Iced.Style.Status
 import Iced.Theme
 
 data NativeTextEditor

--- a/src/Iced/Widget/TextInput.hs
+++ b/src/Iced/Widget/TextInput.hs
@@ -21,10 +21,11 @@ import Iced.Attribute.Internal
 import Iced.Attribute.LengthFFI
 import Iced.Attribute.OnInput
 import Iced.Attribute.PaddingFFI
-import Iced.Attribute.Status
 import Iced.Attribute.Style
 import Iced.ColorFFI
 import Iced.Element
+import Iced.Style.Internal
+import Iced.Style.Status
 import Iced.Theme
 
 data NativeTextInput


### PR DESCRIPTION
Organised reexports in a following way:
- `Iced.Widget` only exports widget constructors
- `Iced.Attribute` exports shared attributes and widget attributes
- `Iced.Style` exports style-related attributes such as `hovered` and `background`

This will help to keep track of exports when the attribute becomes shared between widgets (as happened with `onPress` or `onInput`)