### PR TITLE
Added image support to canvas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,5 @@
 * Removed dependency on TemplateHaskell
 * Renamed Command to Task
 * Added mouseArea widget
+* Renamed FrameAction to Action
+* Added image support for canvas

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ option if you need a simple way to build some ui.
 
  - [ ] Widgets
    - [x] button
+   - [x] canvas
    - [x] checkbox
    - [x] column
    - [x] comboBox
@@ -140,16 +141,19 @@ option if you need a simple way to build some ui.
    - [ ] focusNext, focusPrevious
  - [x] Themes
  - [ ] Canvas api
-   - [x] canvas widget
-   - [x] fill path
-   - [x] fillText
-   - [x] pushTransform
-   - [x] popTransform
-   - [x] rotate
-   - [x] scale
-   - [x] stroke path
-   - [x] path methods - circle, lineTo, moveTo, rectangle
-   - [ ] more path methods
+   - [ ] Frame methods
+     - [x] drawImage
+     - [x] fill
+     - [x] fillText
+     - [x] pushTransform
+     - [x] popTransform
+     - [x] rotate
+     - [x] scale
+     - [x] stroke
+     - [ ] more frame methods
+   - [ ] Path methods
+     - [x] circle, lineTo, moveTo, rectangle
+     - [ ] more path methods
  - [ ] Shader
    - [ ] shader widget
    - [ ] attributes

--- a/examples/canvas/Main.hs
+++ b/examples/canvas/Main.hs
@@ -4,6 +4,8 @@
 
 module Main where
 
+import System.Directory (doesFileExist)
+
 import Iced
 import Iced.Attribute
 import Iced.Attribute.Alignment
@@ -11,11 +13,14 @@ import Iced.Attribute.Text
 import Iced.Color
 import Iced.Widget
 import Iced.Widget.Canvas qualified as Canvas
-import Iced.Widget.Canvas.FrameAction
+import Iced.Widget.Canvas.Frame
 import Iced.Widget.Canvas.Shape
 import Iced.Widget.Canvas.Text
 
-data Model = Model {state :: Canvas.State}
+data Model = Model
+  { state :: Canvas.State
+  , filePath :: String
+  }
 
 data Message
 
@@ -23,10 +28,12 @@ update :: Message -> Model -> Model
 update _message model = model
 
 view :: Model -> Element
-view model = canvas [width Fill, height Fill] shapes model.state
+view model = canvas [width Fill, height Fill] actions model.state
+ where
+  actions = shapes model.filePath
 
-shapes :: [FrameAction]
-shapes =
+shapes :: String -> [Action]
+shapes imagePath =
   [ stroke
       [ moveTo 300 300
       , lineTo 300 350
@@ -53,6 +60,7 @@ shapes =
   , scale 1.5
   , fillText $ label "Three" 165 (-422)
   , popTransform
+  , drawImage 50 250 150 150 imagePath
   , stroke
       [ circle 300 500 70
       ]
@@ -78,8 +86,17 @@ label content x y =
     , shaping = Advanced
     }
 
+getFilePath :: String -> IO String
+getFilePath path = do
+  exists <- doesFileExist path
+  pure $
+    if exists
+      then path
+      else "examples/image/watch_3.png"
+
 main :: IO ()
 main = do
+  filePath <- getFilePath "../image/watch_3.png"
   state <- Canvas.newState
-  let model = Model{state = state}
+  let model = Model{state = state, filePath = filePath}
   Iced.run [] "Canvas" model update view

--- a/examples/spaceShooter/Main.hs
+++ b/examples/spaceShooter/Main.hs
@@ -16,7 +16,7 @@ import Iced.Theme
 import Iced.Time
 import Iced.Widget
 import Iced.Widget.Canvas qualified as Canvas
-import Iced.Widget.Canvas.FrameAction
+import Iced.Widget.Canvas.Frame
 import Iced.Widget.Canvas.Shape
 
 data Screen = Start | Game | Win
@@ -197,31 +197,31 @@ view model = container [centerX Fill, centerY Fill] $
         , button [onPress StartGame] "Start new game"
         ]
 
-fillRectangle :: Float -> Float -> Float -> Float -> Color -> FrameAction
+fillRectangle :: Float -> Float -> Float -> Float -> Color -> Action
 fillRectangle x y width_ height_ color_ =
   fill
     [ rectangle x y width_ height_
     ]
     color_
 
-shapes :: Model -> [FrameAction]
+shapes :: Model -> [Action]
 shapes model =
   [drawField, drawShip model.position]
     ++ map drawBullet model.bullets
     ++ map drawEnemy model.enemies
 
-drawField :: FrameAction
+drawField :: Action
 drawField = fillRectangle 0 0 640 480 (rgb8 0 0 0)
 
-drawShip :: Position -> FrameAction
+drawShip :: Position -> Action
 drawShip Position{..} = fillRectangle (x - 50) y 100 30 (rgb8 180 180 180)
 
-drawBullet :: Bullet -> FrameAction
+drawBullet :: Bullet -> Action
 drawBullet bullet = fillRectangle x y 4 20 $ rgb8 180 180 180
  where
   Position{..} = bullet.position
 
-drawEnemy :: Enemy -> FrameAction
+drawEnemy :: Enemy -> Action
 drawEnemy enemy = fillRectangle x y 40 40 $ rgb8 180 180 180
  where
   Position{..} = enemy.position

--- a/iced-hs.cabal
+++ b/iced-hs.cabal
@@ -17,6 +17,9 @@ tested-with:
 -- cabal-gild: discover rust-src/ Cargo.toml
 extra-source-files:
   Cargo.toml
+  rust-src/advanced/mod.rs
+  rust-src/advanced/image/mod.rs
+  rust-src/advanced/image/handle.rs
   rust-src/alignment.rs
   rust-src/color.rs
   rust-src/ffi.rs
@@ -135,6 +138,8 @@ library
   -- cabal-gild: discover src
   exposed-modules:
     Iced
+    Iced.Advanced.Image
+    Iced.Advanced.Image.Handle
     Iced.Application
     Iced.Attribute
     Iced.Attribute.Alignment
@@ -185,7 +190,7 @@ library
     Iced.Widget.Canvas.Fill
     Iced.Widget.Canvas.Frame
     Iced.Widget.Canvas.FrameAction
-    Iced.Widget.Canvas.FramePtr
+    Iced.Widget.Canvas.FrameFFI
     Iced.Widget.Canvas.Path
     Iced.Widget.Canvas.PathBuilder
     Iced.Widget.Canvas.Shape
@@ -222,12 +227,13 @@ executable buttonStyles
 executable canvas
   import: examples-common
   main-is: canvas/Main.hs
+  build-depends:
+    directory,
 
 executable checkbox
   import: examples-common
   main-is: checkbox/Main.hs
   build-depends:
-    bytestring,
     directory,
 
 executable comboBox

--- a/rust-src/advanced/image/handle.rs
+++ b/rust-src/advanced/image/handle.rs
@@ -1,0 +1,28 @@
+use std::ffi::{c_char, c_uint};
+
+use iced::advanced::image::Handle;
+
+use crate::ffi::{into_raw, read_c_string, read_vec};
+
+#[no_mangle]
+extern "C" fn image_handle_from_path(path_raw: *mut c_char) -> *mut Handle {
+    let path = read_c_string(path_raw);
+    into_raw(Handle::from_path(path))
+}
+
+#[no_mangle]
+extern "C" fn image_handle_from_bytes(len: usize, array_ptr: *const u8) -> *mut Handle {
+    let bytes = read_vec(len, array_ptr);
+    into_raw(Handle::from_bytes(bytes))
+}
+
+#[no_mangle]
+extern "C" fn image_handle_from_rgba(
+    width: c_uint,
+    height: c_uint,
+    len: usize,
+    array_ptr: *const u8,
+) -> *mut Handle {
+    let pixels = read_vec(len, array_ptr);
+    into_raw(Handle::from_rgba(width, height, pixels))
+}

--- a/rust-src/advanced/image/mod.rs
+++ b/rust-src/advanced/image/mod.rs
@@ -1,0 +1,34 @@
+use std::ffi::{c_float, c_uchar};
+
+use iced::advanced::image::{Handle, Image};
+
+use crate::ffi::{from_raw, into_raw, read_c_bool};
+
+mod handle;
+
+type SelfPtr = *mut Image<Handle>;
+
+#[no_mangle]
+extern "C" fn advanced_image_new(handle_ptr: *mut Handle) -> SelfPtr {
+    let handle = from_raw(handle_ptr);
+    into_raw(Image::new(handle))
+}
+
+#[no_mangle]
+extern "C" fn advanced_image_opacity(self_ptr: SelfPtr, opacity: c_float) -> SelfPtr {
+    let image = from_raw(self_ptr);
+    into_raw(image.opacity(opacity))
+}
+
+#[no_mangle]
+extern "C" fn advanced_image_rotation(self_ptr: SelfPtr, radians: c_float) -> SelfPtr {
+    let image = from_raw(self_ptr);
+    into_raw(image.rotation(radians))
+}
+
+#[no_mangle]
+extern "C" fn advanced_image_snap(self_ptr: SelfPtr, snap_raw: c_uchar) -> SelfPtr {
+    let image = from_raw(self_ptr);
+    let snap = read_c_bool(snap_raw);
+    into_raw(image.snap(snap))
+}

--- a/rust-src/advanced/mod.rs
+++ b/rust-src/advanced/mod.rs
@@ -1,0 +1,1 @@
+mod image;

--- a/rust-src/ffi.rs
+++ b/rust-src/ffi.rs
@@ -1,7 +1,29 @@
+use std::ffi::{c_char, c_uchar, CString};
+
 pub(crate) fn from_raw<T>(ptr: *mut T) -> T {
     unsafe { *Box::from_raw(ptr) }
 }
 
 pub(crate) fn into_raw<T>(value: T) -> *mut T {
     Box::into_raw(Box::new(value))
+}
+
+pub(crate) fn read_c_string(input: *mut c_char) -> String {
+    let c_string = unsafe { CString::from_raw(input) };
+    c_string
+        .into_string()
+        .expect("Should convert CString to String")
+}
+
+pub(crate) fn read_vec(len: usize, array_ptr: *const u8) -> Vec<u8> {
+    let slice = unsafe { std::slice::from_raw_parts(array_ptr, len) };
+    slice.to_vec()
+}
+
+pub(crate) fn read_c_bool(input: c_uchar) -> bool {
+    match input {
+        0 => false,
+        1 => true,
+        other => panic!("Non boolean value passed as CBool: {other}"),
+    }
 }

--- a/rust-src/lib.rs
+++ b/rust-src/lib.rs
@@ -6,6 +6,7 @@ use iced::{window, Element, Renderer, Settings, Subscription, Task, Theme};
 use iced_widget::graphics;
 use iced_winit::Program;
 
+mod advanced;
 mod alignment;
 mod color;
 mod ffi;
@@ -21,11 +22,10 @@ mod theme;
 mod time;
 mod widget;
 
-use ffi::{from_raw, into_raw};
+use ffi::{from_raw, into_raw, read_c_string};
 use subscription::SubscriptionFn;
 use task::UpdateResult;
 use theme::{theme_from_raw, ThemeFn};
-use widget::read_c_string;
 
 type Model = *const u8;
 type Message = *const u8;

--- a/rust-src/widget/button.rs
+++ b/rust-src/widget/button.rs
@@ -4,7 +4,8 @@ use button::{Status, Style};
 use iced::widget::{button, text, Button};
 use iced::{Background, Border, Color, Length, Padding};
 
-use super::{read_c_string, ElementPtr, IcedMessage};
+use super::{ElementPtr, IcedMessage};
+use crate::ffi::read_c_string;
 
 type SelfPtr = *mut Button<'static, IcedMessage>;
 

--- a/rust-src/widget/canvas/frame.rs
+++ b/rust-src/widget/canvas/frame.rs
@@ -1,8 +1,28 @@
 use std::ffi::c_float;
 
-use iced::widget::canvas::Text;
-use iced::widget::canvas::{Fill, Frame, Path, Stroke};
-use iced::{Point, Size};
+use iced::widget::canvas::{Fill, Frame, Image, Path, Stroke, Text};
+use iced::{Point, Rectangle, Size};
+
+use crate::ffi::from_raw;
+
+#[no_mangle]
+extern "C" fn canvas_frame_draw_image(
+    frame: &mut Frame,
+    x: c_float,
+    y: c_float,
+    width: c_float,
+    height: c_float,
+    image_ptr: *mut Image,
+) {
+    let bounds = Rectangle {
+        x,
+        y,
+        width,
+        height,
+    };
+    let image = from_raw(image_ptr);
+    frame.draw_image(bounds, image);
+}
 
 #[no_mangle]
 extern "C" fn canvas_frame_fill(frame: &mut Frame, path_ptr: *mut Path, fill_ptr: *mut Fill) {
@@ -22,13 +42,13 @@ extern "C" fn canvas_frame_fill_rectangle(
 ) {
     let top_left = Point::new(top_left_x, top_left_y);
     let size = Size::new(size_width, size_height);
-    let fill = unsafe { *Box::from_raw(fill_ptr) };
+    let fill = from_raw(fill_ptr);
     frame.fill_rectangle(top_left, size, fill);
 }
 
 #[no_mangle]
 extern "C" fn canvas_frame_fill_text(frame: &mut Frame, text_ptr: *mut Text) {
-    let text = unsafe { *Box::from_raw(text_ptr) };
+    let text = from_raw(text_ptr);
     frame.fill_text(text);
 }
 
@@ -54,7 +74,7 @@ extern "C" fn canvas_frame_scale(frame: &mut Frame, value: c_float) {
 
 #[no_mangle]
 extern "C" fn canvas_frame_stroke(frame: &mut Frame, path_ptr: *mut Path, stroke_ptr: *mut Stroke) {
-    let path = unsafe { Box::from_raw(path_ptr) };
-    let stroke = unsafe { *Box::from_raw(stroke_ptr) };
+    let path = from_raw(path_ptr);
+    let stroke = from_raw(stroke_ptr);
     frame.stroke(&path, stroke);
 }

--- a/rust-src/widget/canvas/text.rs
+++ b/rust-src/widget/canvas/text.rs
@@ -4,7 +4,8 @@ use iced::widget::canvas::Text;
 use iced::widget::text::LineHeight;
 use iced::{Alignment, Color, Font, Point};
 
-use crate::widget::{read_c_string, read_shaping};
+use crate::ffi::read_c_string;
+use crate::widget::read_shaping;
 
 #[no_mangle]
 extern "C" fn canvas_text_new(

--- a/rust-src/widget/checkbox.rs
+++ b/rust-src/widget/checkbox.rs
@@ -5,7 +5,8 @@ use iced::widget::{checkbox, text, Checkbox};
 use iced::{Background, Border, Color, Font, Length};
 use text::{LineHeight, Shaping};
 
-use super::{read_c_bool, read_c_string, read_shaping, ElementPtr, IcedMessage};
+use super::{read_shaping, ElementPtr, IcedMessage};
+use crate::ffi::{read_c_bool, read_c_string};
 
 type SelfPtr = *mut Checkbox<'static, IcedMessage>;
 type IconPtr = *mut Icon<Font>;

--- a/rust-src/widget/combo_box.rs
+++ b/rust-src/widget/combo_box.rs
@@ -5,7 +5,8 @@ use iced::widget::text::LineHeight;
 use iced::widget::{combo_box, ComboBox};
 use iced::{Length, Padding};
 
-use super::{read_c_string, ElementPtr, IcedMessage};
+use super::{ElementPtr, IcedMessage};
+use crate::ffi::read_c_string;
 
 type SelfPtr = *mut ComboBox<'static, String, IcedMessage>;
 type StatePtr = *mut State<String>;

--- a/rust-src/widget/image.rs
+++ b/rust-src/widget/image.rs
@@ -1,58 +1,33 @@
-use std::ffi::{c_char, c_uint};
-
+use iced::advanced::image::Handle;
 use iced::widget::{image, Image};
 use iced::Length;
-use image::Handle;
 
-use super::{read_c_string, read_vec, ElementPtr};
+use super::ElementPtr;
+use crate::ffi::{from_raw, into_raw};
 
 type SelfPtr = *mut Image<Handle>;
 
 #[no_mangle]
-extern "C" fn image_handle_from_path(path_raw: *mut c_char) -> *mut Handle {
-    let path = read_c_string(path_raw);
-    Box::into_raw(Box::new(Handle::from_path(path)))
-}
-
-#[no_mangle]
-extern "C" fn image_handle_from_bytes(len: usize, array_ptr: *const u8) -> *mut Handle {
-    let bytes = read_vec(len, array_ptr);
-    Box::into_raw(Box::new(Handle::from_bytes(bytes)))
-}
-
-#[no_mangle]
-extern "C" fn image_handle_from_rgba(
-    width: c_uint,
-    height: c_uint,
-    len: usize,
-    array_ptr: *const u8,
-) -> *mut Handle {
-    let pixels = read_vec(len, array_ptr);
-    Box::into_raw(Box::new(Handle::from_rgba(width, height, pixels)))
-}
-
-#[no_mangle]
 extern "C" fn image_new(handle_ptr: *mut Handle) -> SelfPtr {
-    let handle = unsafe { *Box::from_raw(handle_ptr) };
-    Box::into_raw(Box::new(image(handle)))
+    let handle = from_raw(handle_ptr);
+    into_raw(image(handle))
 }
 
 #[no_mangle]
 extern "C" fn image_width(self_ptr: SelfPtr, width: *mut Length) -> SelfPtr {
-    let image = unsafe { Box::from_raw(self_ptr) };
-    let width = unsafe { *Box::from_raw(width) };
-    Box::into_raw(Box::new(image.width(width)))
+    let image = from_raw(self_ptr);
+    let width = from_raw(width);
+    into_raw(image.width(width))
 }
 
 #[no_mangle]
 extern "C" fn image_height(self_ptr: SelfPtr, height: *mut Length) -> SelfPtr {
-    let image = unsafe { Box::from_raw(self_ptr) };
-    let height = unsafe { *Box::from_raw(height) };
-    Box::into_raw(Box::new(image.height(height)))
+    let image = from_raw(self_ptr);
+    let height = from_raw(height);
+    into_raw(image.height(height))
 }
 
 #[no_mangle]
 extern "C" fn image_into_element(self_ptr: SelfPtr) -> ElementPtr {
-    let image = unsafe { *Box::from_raw(self_ptr) };
-    Box::into_raw(Box::new(image.into()))
+    into_raw(from_raw(self_ptr).into())
 }

--- a/rust-src/widget/markdown.rs
+++ b/rust-src/widget/markdown.rs
@@ -2,7 +2,8 @@ use std::ffi::{c_char, c_uchar};
 
 use iced::widget::markdown::{self, Item};
 
-use super::{read_c_string, ElementPtr};
+use super::ElementPtr;
+use crate::ffi::read_c_string;
 
 type StatePtr = *mut State;
 

--- a/rust-src/widget/mod.rs
+++ b/rust-src/widget/mod.rs
@@ -26,29 +26,10 @@ mod toggler;
 mod tooltip;
 mod vertical_slider;
 
+use crate::ffi::read_c_string;
 use crate::IcedMessage;
 
 pub type ElementPtr = *mut iced::Element<'static, IcedMessage>;
-
-pub fn read_c_string(input: *mut c_char) -> String {
-    let c_string = unsafe { CString::from_raw(input) };
-    c_string
-        .into_string()
-        .expect("Should convert CString to String")
-}
-
-fn read_vec(len: usize, array_ptr: *const u8) -> Vec<u8> {
-    let slice = unsafe { std::slice::from_raw_parts(array_ptr, len) };
-    slice.to_vec()
-}
-
-fn read_c_bool(input: c_uchar) -> bool {
-    match input {
-        0 => false,
-        1 => true,
-        other => panic!("Non boolean value passed as CBool: {other}"),
-    }
-}
 
 fn read_array_of_c_strings(
     len: usize,

--- a/rust-src/widget/pick_list.rs
+++ b/rust-src/widget/pick_list.rs
@@ -4,7 +4,8 @@ use iced::widget::{pick_list, PickList};
 use iced::{Background, Border, Color, Length, Padding};
 use pick_list::{Status, Style};
 
-use super::{read_c_string, ElementPtr, IcedMessage};
+use super::{ElementPtr, IcedMessage};
+use crate::ffi::read_c_string;
 
 type SelfPtr = *mut PickList<'static, String, Vec<String>, String, IcedMessage>;
 

--- a/rust-src/widget/radio.rs
+++ b/rust-src/widget/radio.rs
@@ -4,7 +4,8 @@ use iced::widget::{radio, Radio};
 use iced::{Background, Color, Length};
 use radio::{Status, Style};
 
-use super::{read_c_string, ElementPtr, IcedMessage};
+use super::{ElementPtr, IcedMessage};
+use crate::ffi::read_c_string;
 
 type SelfPtr = *mut Radio<'static, IcedMessage>;
 

--- a/rust-src/widget/text.rs
+++ b/rust-src/widget/text.rs
@@ -4,7 +4,8 @@ use iced::widget::{text, Text};
 use iced::{Color, Length};
 use text::Style;
 
-use super::{read_c_string, ElementPtr};
+use super::ElementPtr;
+use crate::ffi::read_c_string;
 
 type SelfPtr = *mut Text<'static>;
 

--- a/rust-src/widget/text_editor.rs
+++ b/rust-src/widget/text_editor.rs
@@ -5,7 +5,8 @@ use iced::widget::{text_editor, TextEditor};
 use iced::{Background, Border, Color, Length, Padding};
 use text_editor::{Action, Content, Status, Style};
 
-use super::{read_c_string, ElementPtr, IcedMessage};
+use super::{ElementPtr, IcedMessage};
+use crate::ffi::read_c_string;
 
 type SelfPtr = *mut TextEditor<'static, PlainText, IcedMessage>;
 

--- a/rust-src/widget/text_input.rs
+++ b/rust-src/widget/text_input.rs
@@ -4,7 +4,8 @@ use iced::widget::{text_input, TextInput};
 use iced::{Background, Border, Color, Length, Padding};
 use text_input::{Status, Style};
 
-use super::{read_c_string, ElementPtr, IcedMessage};
+use super::{ElementPtr, IcedMessage};
+use crate::ffi::read_c_string;
 
 type SelfPtr = *mut TextInput<'static, IcedMessage>;
 

--- a/rust-src/widget/toggler.rs
+++ b/rust-src/widget/toggler.rs
@@ -3,7 +3,8 @@ use std::ffi::{c_char, c_float, c_uchar};
 use iced::widget::{toggler, Toggler};
 use iced::Length;
 
-use super::{read_c_bool, read_c_string, ElementPtr, IcedMessage};
+use super::{ElementPtr, IcedMessage};
+use crate::ffi::{read_c_bool, read_c_string};
 
 type SelfPtr = *mut Toggler<'static, IcedMessage>;
 

--- a/rust-src/widget/tooltip.rs
+++ b/rust-src/widget/tooltip.rs
@@ -3,7 +3,8 @@ use std::ffi::{c_float, c_uchar};
 use iced::widget::tooltip::Position;
 use iced::widget::{self, Tooltip};
 
-use super::{read_c_bool, ElementPtr, IcedMessage};
+use super::{ElementPtr, IcedMessage};
+use crate::ffi::read_c_bool;
 
 type SelfPtr = *mut Tooltip<'static, IcedMessage>;
 

--- a/src/Iced/Advanced/Image.hs
+++ b/src/Iced/Advanced/Image.hs
@@ -1,0 +1,39 @@
+module Iced.Advanced.Image (
+  ImagePtr,
+  imageNew,
+  imageOpacity,
+  imageRotation,
+  imageSnap,
+) where
+
+import Foreign
+import Foreign.C.Types
+
+import Iced.Advanced.Image.Handle
+
+data NativeImage
+type ImagePtr = Ptr NativeImage
+
+foreign import ccall "advanced_image_new"
+  image_new :: Handle -> IO ImagePtr
+
+foreign import ccall "advanced_image_opacity"
+  image_opacity :: ImagePtr -> CFloat -> ImagePtr
+
+foreign import ccall "advanced_image_rotation"
+  image_rotation :: ImagePtr -> CFloat -> ImagePtr
+
+foreign import ccall "advanced_image_snap"
+  image_snap :: ImagePtr -> CBool -> ImagePtr
+
+imageNew :: Handle -> IO ImagePtr
+imageNew = image_new
+
+imageOpacity :: ImagePtr -> Float -> ImagePtr
+imageOpacity image = image_opacity image . CFloat
+
+imageRotation :: ImagePtr -> Float -> ImagePtr
+imageRotation image = image_rotation image . CFloat
+
+imageSnap :: ImagePtr -> Bool -> ImagePtr
+imageSnap image = image_snap image . fromBool

--- a/src/Iced/Advanced/Image/Handle.hs
+++ b/src/Iced/Advanced/Image/Handle.hs
@@ -1,0 +1,54 @@
+module Iced.Advanced.Image.Handle (
+  Handle,
+  IntoHandle,
+  intoHandle,
+  handleFromPath,
+  handleFromBytes,
+  handleFromRgba,
+) where
+
+import Control.Monad
+import Data.ByteString qualified as ByteString
+import Data.ByteString.Internal qualified as ByteStringInternal
+import Foreign
+import Foreign.C.String
+import Foreign.C.Types
+
+data NativeHandle
+type Handle = Ptr NativeHandle
+
+foreign import ccall "image_handle_from_path"
+  handle_from_path :: CString -> IO Handle
+
+handleFromPath :: String -> IO Handle
+handleFromPath = handle_from_path <=< newCString
+
+-- len bytes
+foreign import ccall "image_handle_from_bytes"
+  handle_from_bytes :: CUInt -> Ptr Word8 -> IO Handle
+
+handleFromBytes :: Int -> Ptr Word8 -> IO Handle
+handleFromBytes len = handle_from_bytes (fromIntegral len)
+
+-- width height len pixels
+foreign import ccall "image_handle_from_rgba"
+  handle_from_rgba :: CUInt -> CUInt -> CUInt -> Ptr Word8 -> IO Handle
+
+handleFromRgba :: Int -> Int -> [Word8] -> IO Handle
+handleFromRgba w h pixels = do
+  let len = fromIntegral $ length pixels
+  pixelsPtr <- newArray pixels
+  handle <- handle_from_rgba (fromIntegral w) (fromIntegral h) len pixelsPtr
+  free pixelsPtr
+  pure handle
+
+class IntoHandle a where
+  intoHandle :: a -> IO Handle
+
+instance IntoHandle String where
+  intoHandle = handleFromPath
+
+instance IntoHandle ByteString.ByteString where
+  intoHandle byteString = withForeignPtr ptr $ handleFromBytes len
+   where
+    (ptr, len) = ByteStringInternal.toForeignPtr0 byteString

--- a/src/Iced/Widget/Canvas.hs
+++ b/src/Iced/Widget/Canvas.hs
@@ -15,8 +15,7 @@ import Iced.Attribute.Internal
 import Iced.Attribute.LengthFFI
 import Iced.Element
 import Iced.Widget.Canvas.Frame
-import Iced.Widget.Canvas.FrameAction
-import Iced.Widget.Canvas.FramePtr
+import Iced.Widget.Canvas.FrameFFI
 
 data NativeState
 type State = ForeignPtr NativeState
@@ -67,25 +66,12 @@ foreign import ccall "wrapper"
   makeDrawCallback :: NativeDraw -> IO (FunPtr (NativeDraw))
 
 data Canvas = Canvas
-  { actions :: [FrameAction]
+  { actions :: [Action]
   , cache :: State
   }
 
-drawActions :: [FrameAction] -> FramePtr -> IO ()
-drawActions [] _framePtr = pure ()
-drawActions (action : remaining) framePtr = do
-  case action of
-    FrameFill shapes color -> frameFill framePtr shapes color
-    FrameFillText text -> frameFillText framePtr text
-    FramePushTransform -> framePushTransform framePtr
-    FramePopTransform -> framePopTransform framePtr
-    FrameRotate angle -> frameRotate framePtr angle
-    FrameScale value -> frameScale framePtr value
-    FrameStroke shapes color width -> frameStroke framePtr shapes color width
-  drawActions remaining framePtr
-
-drawCallback :: [FrameAction] -> NativeDraw
-drawCallback actions framePtr = drawActions actions framePtr
+drawCallback :: [Action] -> NativeDraw
+drawCallback = useActions
 
 instance Builder Self where
   build = into_element
@@ -107,5 +93,5 @@ instance UseWidth Length Attribute where
 instance UseHeight Length Attribute where
   height = Height
 
-canvas :: [Attribute] -> [FrameAction] -> State -> Element
+canvas :: [Attribute] -> [Action] -> State -> Element
 canvas attributes actions cache = pack Canvas{..} attributes

--- a/src/Iced/Widget/Canvas/Frame.hs
+++ b/src/Iced/Widget/Canvas/Frame.hs
@@ -1,73 +1,48 @@
-module Iced.Widget.Canvas.Frame where
+module Iced.Widget.Canvas.Frame (
+  Action,
+  drawImage,
+  fill,
+  fillText,
+  pushTransform,
+  popTransform,
+  rotate,
+  scale,
+  stroke,
+) where
 
-import Control.Monad
-import Foreign.C.Types
-
+import Iced.Advanced.Image.Handle
 import Iced.Color
-import Iced.Widget.Canvas.Fill
-import Iced.Widget.Canvas.FramePtr
-import Iced.Widget.Canvas.Path
+import Iced.Widget.Canvas.FrameAction
 import Iced.Widget.Canvas.Shape
-import Iced.Widget.Canvas.Stroke
-import Iced.Widget.Canvas.Style
-import Iced.Widget.Canvas.TextFFI
+import Iced.Widget.Canvas.Text
 
-foreign import ccall "canvas_frame_fill"
-  canvas_frame_fill :: FramePtr -> PathPtr -> FillPtr -> IO ()
+drawImage
+  :: IntoHandle a
+  => Float -- top left x
+  -> Float -- top left y
+  -> Float -- width
+  -> Float -- height
+  -> a
+  -> Action
+drawImage x y width height input = DrawImage x y width height $ intoHandle input
 
-foreign import ccall "canvas_frame_fill_rectangle"
-  canvas_frame_fill_rectangle
-    :: FramePtr
-    -> CFloat -- top_left x
-    -> CFloat -- top_left y
-    -> CFloat -- size width
-    -> CFloat -- size height
-    -> FillPtr
-    -> IO ()
+fill :: [Shape] -> Color -> Action
+fill shapes color = Fill shapes color
 
-foreign import ccall "canvas_frame_fill_text"
-  canvas_frame_fill_text :: FramePtr -> TextPtr -> IO ()
+fillText :: Text -> Action
+fillText = FillText
 
-foreign import ccall "canvas_frame_pop_transform"
-  canvas_frame_pop_transform :: FramePtr -> IO ()
+pushTransform :: Action
+pushTransform = PushTransform
 
-foreign import ccall "canvas_frame_push_transform"
-  canvas_frame_push_transform :: FramePtr -> IO ()
+popTransform :: Action
+popTransform = PopTransform
 
-foreign import ccall "canvas_frame_rotate"
-  canvas_frame_rotate :: FramePtr -> CFloat -> IO ()
+rotate :: Float -> Action
+rotate = Rotate
 
-foreign import ccall "canvas_frame_scale"
-  canvas_frame_scale :: FramePtr -> CFloat -> IO ()
+scale :: Float -> Action
+scale = Scale
 
-foreign import ccall "canvas_frame_stroke"
-  canvas_frame_stroke :: FramePtr -> PathPtr -> StrokePtr -> IO ()
-
-frameFill :: FramePtr -> [Shape] -> Color -> IO ()
-frameFill framePtr shapes color = do
-  path <- newPath shapes
-  style <- solid color
-  fill <- newCanvasFill style NonZero
-  canvas_frame_fill framePtr path fill
-
-frameFillText :: FramePtr -> Text -> IO ()
-frameFillText framePtr = canvas_frame_fill_text framePtr <=< newCanvasText
-
-framePopTransform :: FramePtr -> IO ()
-framePopTransform = canvas_frame_pop_transform
-
-framePushTransform :: FramePtr -> IO ()
-framePushTransform = canvas_frame_push_transform
-
-frameRotate :: FramePtr -> Float -> IO ()
-frameRotate framePtr = canvas_frame_rotate framePtr . CFloat
-
-frameScale :: FramePtr -> Float -> IO ()
-frameScale framePtr = canvas_frame_scale framePtr . CFloat
-
-frameStroke :: FramePtr -> [Shape] -> Color -> Float -> IO ()
-frameStroke framePtr shapes color width = do
-  path <- newPath shapes
-  style <- solid color
-  stroke <- newCanvasStroke style width Butt Miter
-  canvas_frame_stroke framePtr path stroke
+stroke :: [Shape] -> Color -> Float -> Action
+stroke shapes color width = Stroke shapes color width

--- a/src/Iced/Widget/Canvas/FrameAction.hs
+++ b/src/Iced/Widget/Canvas/FrameAction.hs
@@ -1,35 +1,18 @@
-module Iced.Widget.Canvas.FrameAction where
+module Iced.Widget.Canvas.FrameAction (
+  Action (..),
+) where
 
-import Iced.Color
-import Iced.Widget.Canvas.Shape
-import Iced.Widget.Canvas.Text
+import Iced.Advanced.Image.Handle (Handle)
+import Iced.Color (Color)
+import Iced.Widget.Canvas.Shape (Shape)
+import Iced.Widget.Canvas.Text (Text)
 
-data FrameAction
-  = FrameFill [Shape] Color
-  | FrameFillText Text
-  | FramePushTransform
-  | FramePopTransform
-  | FrameRotate Float
-  | FrameScale Float
-  | FrameStroke [Shape] Color Float
-
-fill :: [Shape] -> Color -> FrameAction
-fill shapes color = FrameFill shapes color
-
-fillText :: Text -> FrameAction
-fillText = FrameFillText
-
-pushTransform :: FrameAction
-pushTransform = FramePushTransform
-
-popTransform :: FrameAction
-popTransform = FramePopTransform
-
-rotate :: Float -> FrameAction
-rotate = FrameRotate
-
-scale :: Float -> FrameAction
-scale = FrameScale
-
-stroke :: [Shape] -> Color -> Float -> FrameAction
-stroke shapes color width = FrameStroke shapes color width
+data Action
+  = DrawImage Float Float Float Float (IO Handle)
+  | Fill [Shape] Color
+  | FillText Text
+  | PushTransform
+  | PopTransform
+  | Rotate Float
+  | Scale Float
+  | Stroke [Shape] Color Float

--- a/src/Iced/Widget/Canvas/FrameFFI.hs
+++ b/src/Iced/Widget/Canvas/FrameFFI.hs
@@ -1,0 +1,115 @@
+module Iced.Widget.Canvas.FrameFFI (
+  FramePtr,
+  useActions,
+) where
+
+import Control.Monad
+import Foreign
+import Foreign.C.Types
+
+import Iced.Advanced.Image
+import Iced.Advanced.Image.Handle
+import Iced.Color
+import Iced.Widget.Canvas.Fill
+import Iced.Widget.Canvas.FrameAction
+import Iced.Widget.Canvas.Path
+import Iced.Widget.Canvas.Shape
+import Iced.Widget.Canvas.Stroke
+import Iced.Widget.Canvas.Style
+import Iced.Widget.Canvas.TextFFI
+
+data NativeFrame
+type FramePtr = Ptr NativeFrame
+
+foreign import ccall "canvas_frame_draw_image"
+  draw_image
+    :: FramePtr
+    -> CFloat -- top left x
+    -> CFloat -- top left y
+    -> CFloat -- width
+    -> CFloat -- height
+    -> ImagePtr
+    -> IO ()
+
+foreign import ccall "canvas_frame_fill"
+  frame_fill :: FramePtr -> PathPtr -> FillPtr -> IO ()
+
+foreign import ccall "canvas_frame_fill_rectangle"
+  fill_rectangle
+    :: FramePtr
+    -> CFloat -- top left x
+    -> CFloat -- top left y
+    -> CFloat -- width
+    -> CFloat -- height
+    -> FillPtr
+    -> IO ()
+
+foreign import ccall "canvas_frame_fill_text"
+  fill_text :: FramePtr -> TextPtr -> IO ()
+
+foreign import ccall "canvas_frame_pop_transform"
+  pop_transform :: FramePtr -> IO ()
+
+foreign import ccall "canvas_frame_push_transform"
+  push_transform :: FramePtr -> IO ()
+
+foreign import ccall "canvas_frame_rotate"
+  frame_rotate :: FramePtr -> CFloat -> IO ()
+
+foreign import ccall "canvas_frame_scale"
+  frame_scale :: FramePtr -> CFloat -> IO ()
+
+foreign import ccall "canvas_frame_stroke"
+  frame_stroke :: FramePtr -> PathPtr -> StrokePtr -> IO ()
+
+useActions :: [Action] -> FramePtr -> IO ()
+useActions [] _framePtr = pure ()
+useActions (action : remaining) framePtr = do
+  applyAction action framePtr
+  useActions remaining framePtr
+
+applyAction :: Action -> FramePtr -> IO ()
+applyAction action framePtr = do
+  case action of
+    DrawImage x y width height handle -> drawImage framePtr x y width height =<< handle
+    Fill shapes color -> frameFill framePtr shapes color
+    FillText text -> fillText framePtr text
+    PushTransform -> push_transform framePtr
+    PopTransform -> pop_transform framePtr
+    Rotate angle -> frameRotate framePtr angle
+    Scale value -> frameScale framePtr value
+    Stroke shapes color width -> frameStroke framePtr shapes color width
+
+drawImage
+  :: FramePtr
+  -> Float -- top left x
+  -> Float -- top left y
+  -> Float -- width
+  -> Float -- height
+  -> Handle
+  -> IO ()
+drawImage framePtr x y width height =
+  draw_image framePtr (CFloat x) (CFloat y) (CFloat width) (CFloat height) <=< imageNew
+
+frameFill :: FramePtr -> [Shape] -> Color -> IO ()
+frameFill framePtr shapes color = do
+  path <- newPath shapes
+  style <- solid color
+  fill <- newCanvasFill style NonZero
+  frame_fill framePtr path fill
+
+fillText :: FramePtr -> Text -> IO ()
+fillText framePtr = fill_text framePtr <=< newCanvasText
+
+frameRotate :: FramePtr -> Float -> IO ()
+frameRotate framePtr = frame_rotate framePtr . CFloat
+
+frameScale :: FramePtr -> Float -> IO ()
+frameScale framePtr = frame_scale framePtr . CFloat
+
+frameStroke :: FramePtr -> [Shape] -> Color -> Float -> IO ()
+frameStroke framePtr shapes color width = do
+  path <- newPath shapes
+  style <- solid color
+  stroke <- newCanvasStroke style width Butt Miter
+  frame_stroke framePtr path stroke

--- a/src/Iced/Widget/Canvas/FramePtr.hs
+++ b/src/Iced/Widget/Canvas/FramePtr.hs
@@ -1,6 +1,0 @@
-module Iced.Widget.Canvas.FramePtr where
-
-import Foreign
-
-data NativeFrame
-type FramePtr = Ptr NativeFrame

--- a/src/Iced/Widget/Image.hs
+++ b/src/Iced/Widget/Image.hs
@@ -7,48 +7,20 @@ module Iced.Widget.Image (
   fromRgba,
 ) where
 
-import Control.Monad
-import Data.ByteString qualified as ByteString
-import Data.ByteString.Internal qualified as ByteStringInternal
 import Data.Word
 import Foreign
-import Foreign.C.String
-import Foreign.C.Types
 
+import Iced.Advanced.Image.Handle
 import Iced.Attribute.Internal
 import Iced.Attribute.LengthFFI
 import Iced.Element
 
 data NativeImage
 type Self = Ptr NativeImage
-data NativeHandle
-type Handle = Ptr NativeHandle
 
 data Attribute
   = Width Length
   | Height Length
-
-foreign import ccall "image_handle_from_path"
-  handle_from_path :: CString -> IO Handle
-
-handleFromPath :: String -> IO Handle
-handleFromPath = handle_from_path <=< newCString
-
--- len bytes
-foreign import ccall "image_handle_from_bytes"
-  handle_from_bytes :: CUInt -> Ptr Word8 -> IO Handle
-
--- width height len pixels
-foreign import ccall "image_handle_from_rgba"
-  handle_from_rgba :: CUInt -> CUInt -> CUInt -> Ptr Word8 -> IO Handle
-
-handleFromRgba :: Int -> Int -> [Word8] -> IO Handle
-handleFromRgba w h pixels = do
-  let len = fromIntegral $ length pixels
-  pixelsPtr <- newArray pixels
-  handle <- handle_from_rgba (fromIntegral w) (fromIntegral h) len pixelsPtr
-  free pixelsPtr
-  pure handle
 
 foreign import ccall "image_new"
   image_new :: Handle -> IO Self
@@ -81,17 +53,6 @@ instance UseWidth Length Attribute where
 
 instance UseHeight Length Attribute where
   height = Height
-
-class IntoHandle a where
-  intoHandle :: a -> IO Handle
-
-instance IntoHandle String where
-  intoHandle = handleFromPath
-
-instance IntoHandle ByteString.ByteString where
-  intoHandle byteString = withForeignPtr ptr $ handle_from_bytes (fromIntegral len)
-   where
-    (ptr, len) = ByteStringInternal.toForeignPtr0 byteString
 
 image :: IntoHandle a => [Attribute] -> a -> Element
 image attributes input = pack Image{..} attributes


### PR DESCRIPTION
- Made a few changes to reuse `Handler` from `image` widget.
- Renamed `data FrameAction` to `Action`. Use `Action` or `Frame.Action` instead
- Changed required imports
```haskell
-- from
import Iced.Widget.Canvas.FrameAction
-- to
import Iced.Widget.Canvas.Frame
```
Related to #5 