### PR TITLE
Implemented Drop for some callbacks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,7 @@ edition = "2021"
 
 [lib]
 path = "rust-src/lib.rs"
-crate-type = ["staticlib", "cdylib"]
-name = "iced_hs"
+crate-type = ["staticlib"]
 
 [dependencies.iced]
 # version = "0.13"

--- a/Setup.hs
+++ b/Setup.hs
@@ -157,7 +157,6 @@ rustConfHook (description, buildInfo) flags = do
     "mv"
     [(rustBuildDir </> "libiced_hs.a"), (rustBuildDir </> "libCiced_hs.a")]
   copyFiles (fromFlag $ configVerbosity flags) rawBuildDir [(rustBuildDir, "libCiced_hs.a")]
-  copyFiles (fromFlag $ configVerbosity flags) rawBuildDir [(rustBuildDir, "libiced_hs.so")]
   pure localBuildInfo
 
 getCargoBuildDir :: Bool -> IO (SymbolicPath from to)

--- a/cabal.ci.project
+++ b/cabal.ci.project
@@ -1,4 +1,4 @@
 import: ./cabal.project
 
-flags: +release +cibuild
+flags: +cibuild
 tests: True

--- a/cabal.ci.project
+++ b/cabal.ci.project
@@ -1,3 +1,4 @@
 import: ./cabal.project
 
+flags: +release +cibuild
 tests: True

--- a/iced-hs.cabal
+++ b/iced-hs.cabal
@@ -81,6 +81,16 @@ extra-doc-files:
   docs/VISION.txt
   docs/WIDGETS.md
 
+flag release
+  description: Build Rust library in release mode
+  manual: True
+  default: False
+
+flag cibuild
+  description: Is it a CI build?
+  manual: True
+  default: False
+
 flag examples
   description: Build examples
   manual: True

--- a/rust-src/lib.rs
+++ b/rust-src/lib.rs
@@ -36,7 +36,11 @@ type Update = extern "C" fn(model: Model, message: Message) -> *mut UpdateResult
 type View = extern "C" fn(model: Model) -> ElementPtr;
 
 extern "C" {
+    // Part of HsFFI.h
+    #[link_name = "hs_free_fun_ptr"]
     fn free_haskell_fun_ptr(ptr: usize);
+    // Part of HsFFI.h
+    #[link_name = "hs_free_stable_ptr"]
     fn free_stable_ptr(ptr: *const u8);
 }
 

--- a/rust-src/lib.rs
+++ b/rust-src/lib.rs
@@ -36,9 +36,7 @@ type Update = extern "C" fn(model: Model, message: Message) -> *mut UpdateResult
 type View = extern "C" fn(model: Model) -> ElementPtr;
 
 extern "C" {
-    #[link_name = "hs_free_fun_ptr"]
     fn free_haskell_fun_ptr(ptr: usize);
-    #[link_name = "hs_free_stable_ptr"]
     fn free_stable_ptr(ptr: *const u8);
 }
 

--- a/rust-src/widget/checkbox.rs
+++ b/rust-src/widget/checkbox.rs
@@ -12,7 +12,7 @@ use crate::{ElementPtr, IcedMessage};
 type SelfPtr = *mut Checkbox<'static, IcedMessage>;
 type IconPtr = *mut Icon<Font>;
 
-type OnToggleFFI = extern "C" fn(input: c_uchar) -> *const u8;
+type OnToggleFFI = super::CallbackForCBool;
 
 type StyleCallback =
     extern "C" fn(style: &mut Style, theme: c_uchar, status: c_uchar, is_checked: c_uchar);

--- a/rust-src/widget/combo_box.rs
+++ b/rust-src/widget/combo_box.rs
@@ -11,9 +11,9 @@ use crate::{ElementPtr, IcedMessage};
 type SelfPtr = *mut ComboBox<'static, String, IcedMessage>;
 type StatePtr = *mut State<String>;
 
-type OnSelectFFI = extern "C" fn(selected: *mut c_char) -> *const u8;
-type OnInputFFI = extern "C" fn(input: *mut c_char) -> *const u8;
-type OnOptionHoveredFFI = extern "C" fn(selected: *mut c_char) -> *const u8;
+type OnSelectFFI = super::CallbackForCString;
+type OnInputFFI = super::CallbackForCString;
+type OnOptionHoveredFFI = super::CallbackForCString;
 
 #[no_mangle]
 extern "C" fn combo_box_state_new(

--- a/rust-src/widget/markdown.rs
+++ b/rust-src/widget/markdown.rs
@@ -7,7 +7,7 @@ use crate::ElementPtr;
 
 type StatePtr = *mut State;
 
-type OnUrlClickFFI = extern "C" fn(url: *mut c_char) -> *const u8;
+type OnUrlClickFFI = super::CallbackForCString;
 
 struct State {
     items: Vec<Item>,

--- a/rust-src/widget/pick_list.rs
+++ b/rust-src/widget/pick_list.rs
@@ -9,7 +9,7 @@ use crate::{ElementPtr, IcedMessage};
 
 type SelfPtr = *mut PickList<'static, String, Vec<String>, String, IcedMessage>;
 
-type OnSelectFFI = extern "C" fn(selected: *mut c_char) -> *const u8;
+type OnSelectFFI = super::CallbackForCString;
 
 type StyleCallback = extern "C" fn(style: &mut Style, theme: c_uchar, status: c_uchar);
 

--- a/rust-src/widget/text_input.rs
+++ b/rust-src/widget/text_input.rs
@@ -9,7 +9,7 @@ use crate::{ElementPtr, IcedMessage};
 
 type SelfPtr = *mut TextInput<'static, IcedMessage>;
 
-type OnInputFFI = extern "C" fn(input: *mut c_char) -> *const u8;
+type OnInputFFI = super::CallbackForCString;
 
 type StyleCallback = extern "C" fn(style: &mut Style, theme: c_uchar, status: c_uchar);
 

--- a/rust-src/widget/toggler.rs
+++ b/rust-src/widget/toggler.rs
@@ -8,7 +8,7 @@ use crate::{ElementPtr, IcedMessage};
 
 type SelfPtr = *mut Toggler<'static, IcedMessage>;
 
-type OnToggleFFI = extern "C" fn(input: c_uchar) -> *const u8;
+type OnToggleFFI = super::CallbackForCBool;
 
 #[no_mangle]
 extern "C" fn toggler_new(


### PR DESCRIPTION
Started the work on #7

~~Removed `#[link_name]` attributes because they didn't match actual function names in Haskell, and as a result Haskell functions weren't called~~
Figured out that `hs_free_stable_ptr` and `hs_free_fun_ptr` are parts of `HsFFI.h`